### PR TITLE
Properly handle spaces in paths within install_dependencies

### DIFF
--- a/install_dependencies.py
+++ b/install_dependencies.py
@@ -47,8 +47,8 @@ if __name__ == "__main__":
         vod_recovery_script = os.path.join(script_dir, 'vod_recovery.py')
 
         install_requirements(requirements_file)
-        os.system(f'python {install_ffmpeg_script}')
-        os.system(f'python {vod_recovery_script}')
+        os.system(f'python "{install_ffmpeg_script}"')
+        os.system(f'python "{vod_recovery_script}"')
 
     except Exception as e:
         print(f"An error occurred: {e}")


### PR DESCRIPTION
Otherwise, this happens:
![Screenshot](https://github.com/MacielG1/VodRecovery/assets/2406819/dfe540c3-5ee6-40a0-9701-63359f90633a)
