### PR TITLE
fix ffmpeg linux command

### DIFF
--- a/vod_recovery.py
+++ b/vod_recovery.py
@@ -1814,6 +1814,12 @@ def download_m3u8_video_url_slice(m3u8_link, output_filename, video_start_time, 
 def download_m3u8_video_file(m3u8_file_path, output_filename):
     downloader = get_default_downloader()
 
+ if os.name != 'nt':
+        if not output_filename.startswith("'"):
+            output_filename = "'" + output_filename
+        if not output_filename.endswith("'"):
+            output_filename += "'"
+
     if downloader == "ffmpeg":
         command = [
             get_ffmpeg_path(),


### PR DESCRIPTION
On linux when entering the path of the output the spaces cause an error, I added a single quote to the beginning and end to fix this.

Error:
```
ffmpeg -protocol_whitelist file,http,https,tcp,tls -hide_banner -ignore_unknown -i /home/warny/Downloads/haiset_43018916952.m3u8 -c copy /home/warny/Downloads/haiset - 2024-10-16 - [43018916952].mkv

[AVFormatContext @ 0x24eb640] Unable to choose an output format for '/home/warny/Downloads/haiset'; use a standard extension for the filename or specify the format manually.
[out#0 @ 0x2b286c0] Error initializing the muxer for /home/warny/Downloads/haiset: Invalid argument
Error opening output file /home/warny/Downloads/haiset.
Error opening output files: Invalid argument
```

Running: Linux 6.6.47, NixOS, 24.11 (Vicuna); Python 3.12.4